### PR TITLE
Celica dorm fix

### DIFF
--- a/AscNet.GameServer/Handlers/DormModule.cs
+++ b/AscNet.GameServer/Handlers/DormModule.cs
@@ -166,6 +166,89 @@ internal partial class DormModule
     private const int DormRequestDataInvalid = 20060040;
     private const int PutCharacterRecoveryChangeType = 2;
 
+    internal static bool IsDormRewardCharacter(uint characterId)
+    {
+        return TableReaderV2.Parse<DormCharacterRewardTable>()
+            .Any(row => row.CharacterId == characterId);
+    }
+
+    internal static bool TryGrantDormCharacterReward(Session session, int rewardId)
+    {
+        DormCharacterRewardTable? reward = TableReaderV2.Parse<DormCharacterRewardTable>()
+            .FirstOrDefault(row => row.Id == rewardId);
+        if (reward is null || reward.CharacterId <= 0)
+            return false;
+
+        uint characterId = checked((uint)reward.CharacterId);
+        if (session.player.Dorm.Characters.Any(character => character.CharacterId == characterId))
+            return false;
+
+        Dictionary<string, int> config = Config();
+        DormCharacterFondleTable? fondle = TableReaderV2.Parse<DormCharacterFondleTable>()
+            .FirstOrDefault(row => row.CharacterId == characterId);
+        uint now = checked((uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        session.player.Dorm.Characters.Add(new PlayerDormCharacter
+        {
+            CharacterId = characterId,
+            DormitoryId = -1,
+            Mood = config.GetValueOrDefault("DormMoodInitValue"),
+            Vitality = config.GetValueOrDefault("DormVitalityInitValue"),
+            LeftFondleCount = fondle?.MaxCount ?? 0,
+            LastFondleRecoveryTime = now,
+            LastRecoveryTime = now
+        });
+        return true;
+    }
+
+    private static bool EnsureAllFurniture(PlayerDormState dorm)
+    {
+        const int DesiredCopiesPerFurniture = 7;
+        FurnitureTables tables = FurnitureData.Value;
+        Dictionary<uint, int> ownedCounts = dorm.Furniture
+            .GroupBy(furniture => furniture.ConfigId)
+            .ToDictionary(group => group.Key, group => group.Count());
+        bool changed = false;
+
+        foreach (FurnitureTable config in tables.Furniture)
+        {
+            uint configId = checked((uint)config.Id);
+            if (!dorm.FurnitureUnlocks.Contains(configId))
+            {
+                dorm.FurnitureUnlocks.Add(configId);
+                changed = true;
+            }
+
+            ownedCounts.TryGetValue(configId, out int currentCount);
+            if (currentCount >= DesiredCopiesPerFurniture)
+                continue;
+
+            FurnitureRewardTable? reward = tables.Rewards.FirstOrDefault(row => row.FurnitureId == config.Id);
+            FurnitureExtraAttrTable? extra = reward is null ? null : tables.ExtraAttrs.FirstOrDefault(row => row.Id == reward.ExtraAttrId);
+            FurnitureBaseAttrTable? baseAttr = extra is null ? null : tables.BaseAttrs.FirstOrDefault(row => row.Id == extra.BaseAttrId);
+            List<int> bases = extra?.AttrIds.Take(3).Concat(Enumerable.Repeat(0, 3)).Take(3).ToList() ?? [0, 0, 0];
+            List<int> attrs = baseAttr is null ? [0, 0, 0] : Split(baseAttr.Value, bases).ToList();
+
+            while (currentCount < DesiredCopiesPerFurniture)
+            {
+                dorm.Furniture.Add(new PlayerDormFurniture
+                {
+                    Id = dorm.NextFurnitureId++,
+                    ConfigId = configId,
+                    DormitoryId = -1,
+                    Addition = reward?.AdditionId ?? 0,
+                    AttrList = new List<int>(attrs),
+                    BaseAttrList = new List<int>(bases),
+                    IsLocked = false
+                });
+                currentCount++;
+                changed = true;
+            }
+            ownedCounts[configId] = currentCount;
+        }
+
+        return changed;
+    }
+
     public static NotifyDormitoryData BuildLoginData(Session session)
     {
         Dictionary<string, int> config = Config();
@@ -174,6 +257,10 @@ internal partial class DormModule
         Dictionary<uint, DormCharacterFondleTable> fondles = TableReaderV2.Parse<DormCharacterFondleTable>()
             .ToDictionary(row => (uint)row.CharacterId);
         uint now = checked((uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+        foreach (int rewardId in ShopModule.GetPurchasedDormCharacterRewardIds(session.player))
+            changed |= TryGrantDormCharacterReward(session, rewardId);
+
         foreach (uint characterId in session.character.Characters.Select(character => character.Id).Distinct())
         {
             PlayerDormCharacter? character = session.player.Dorm.Characters.FirstOrDefault(saved => saved.CharacterId == characterId);
@@ -196,6 +283,7 @@ internal partial class DormModule
                 changed |= NormalizeFondle(character, fondles.GetValueOrDefault(characterId), now);
         }
         changed |= NormalizeFreeRooms(session.player.Dorm);
+        changed |= EnsureAllFurniture(session.player.Dorm);
         changed |= session.player.Dorm.NormalizeFurnitureIds();
         changed |= NormalizeWorkRefresh(session.player.Dorm, now);
         changed |= EvaluateEvents(session, now);
@@ -275,7 +363,7 @@ internal partial class DormModule
         bool valid = room is not null && config is not null && request.CharacterIds.Count > 0
             && request.CharacterIds.Distinct().Count() == request.CharacterIds.Count
             && characters.Count == request.CharacterIds.Count
-            && request.CharacterIds.All(owned.Contains)
+            && request.CharacterIds.All(id => owned.Contains(id) || IsDormRewardCharacter(id))
             && characters.All(character => character.DormitoryId == -1)
             && characters.All(character => session.player.Dorm.WorkList.All(work =>
                 work.WorkEndTime == 0 || work.CharacterId != character.CharacterId))

--- a/AscNet.GameServer/Handlers/DormModule.cs
+++ b/AscNet.GameServer/Handlers/DormModule.cs
@@ -202,13 +202,12 @@ internal partial class DormModule
 
     private static bool EnsureAllFurniture(PlayerDormState dorm)
     {
-        const int DesiredCopiesPerFurniture = 7;
         FurnitureTables tables = FurnitureData.Value;
-        Dictionary<uint, int> ownedCounts = dorm.Furniture
-            .GroupBy(furniture => furniture.ConfigId)
-            .ToDictionary(group => group.Key, group => group.Count());
+        HashSet<uint> owned = dorm.Furniture.Select(furniture => furniture.ConfigId).ToHashSet();
         bool changed = false;
 
+        // Every Furniture.tsv entry becomes both unlocked in the catalog and owned as
+        // one placeable item. Existing copies are preserved, so this is idempotent.
         foreach (FurnitureTable config in tables.Furniture)
         {
             uint configId = checked((uint)config.Id);
@@ -218,8 +217,7 @@ internal partial class DormModule
                 changed = true;
             }
 
-            ownedCounts.TryGetValue(configId, out int currentCount);
-            if (currentCount >= DesiredCopiesPerFurniture)
+            if (owned.Contains(configId))
                 continue;
 
             FurnitureRewardTable? reward = tables.Rewards.FirstOrDefault(row => row.FurnitureId == config.Id);
@@ -228,22 +226,18 @@ internal partial class DormModule
             List<int> bases = extra?.AttrIds.Take(3).Concat(Enumerable.Repeat(0, 3)).Take(3).ToList() ?? [0, 0, 0];
             List<int> attrs = baseAttr is null ? [0, 0, 0] : Split(baseAttr.Value, bases).ToList();
 
-            while (currentCount < DesiredCopiesPerFurniture)
+            dorm.Furniture.Add(new PlayerDormFurniture
             {
-                dorm.Furniture.Add(new PlayerDormFurniture
-                {
-                    Id = dorm.NextFurnitureId++,
-                    ConfigId = configId,
-                    DormitoryId = -1,
-                    Addition = reward?.AdditionId ?? 0,
-                    AttrList = new List<int>(attrs),
-                    BaseAttrList = new List<int>(bases),
-                    IsLocked = false
-                });
-                currentCount++;
-                changed = true;
-            }
-            ownedCounts[configId] = currentCount;
+                Id = dorm.NextFurnitureId++,
+                ConfigId = configId,
+                DormitoryId = -1,
+                Addition = reward?.AdditionId ?? 0,
+                AttrList = attrs,
+                BaseAttrList = bases,
+                IsLocked = false
+            });
+            owned.Add(configId);
+            changed = true;
         }
 
         return changed;
@@ -258,6 +252,9 @@ internal partial class DormModule
             .ToDictionary(row => (uint)row.CharacterId);
         uint now = checked((uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
+        // Reconcile special dorm characters that were purchased before DormCharacter
+        // rewards were implemented by the server. ShopBuyTimes is persistent, so this
+        // safely repairs existing purchases on the next login.
         foreach (int rewardId in ShopModule.GetPurchasedDormCharacterRewardIds(session.player))
             changed |= TryGrantDormCharacterReward(session, rewardId);
 

--- a/AscNet.GameServer/Handlers/RewardHandler.cs
+++ b/AscNet.GameServer/Handlers/RewardHandler.cs
@@ -1,4 +1,4 @@
-using AscNet.Common;
+﻿using AscNet.Common;
 using AscNet.Common.Database;
 using AscNet.Common.MsgPack;
 using AscNet.Common.Util;
@@ -42,6 +42,7 @@ namespace AscNet.GameServer.Handlers
         internal NotifyWeaponFashionInfo WeaponFashionData { get; } = new();
         internal NotifyHeadPortraitInfos HeadPortraitData { get; } = new();
         internal bool DormFurnitureChanged { get; set; }
+        internal bool DormCharacterChanged { get; set; }
         internal List<int> GatherRewardIds { get; } = [];
 
 
@@ -63,6 +64,8 @@ namespace AscNet.GameServer.Handlers
                 session.SendPush(new NotifyGatherReward { Id = id });
             if (HeadPortraitData.Heads.Count > 0)
                 session.SendPush(HeadPortraitData);
+            if (DormCharacterChanged)
+                session.SendPush(DormModule.BuildLoginData(session));
         }
 
         internal void AddPushes(RewardApplicationResult source)
@@ -99,6 +102,7 @@ namespace AscNet.GameServer.Handlers
                     HeadPortraitData.Heads.Add(head);
             }
             DormFurnitureChanged |= source.DormFurnitureChanged;
+            DormCharacterChanged |= source.DormCharacterChanged;
 
         }
     }
@@ -512,7 +516,7 @@ namespace AscNet.GameServer.Handlers
             Session session)
         {
             RewardApplicationResult result = ApplyRewards(rewardGoods, session);
-            if (result.DormFurnitureChanged || result.GatherRewardIds.Count > 0 || result.HeadPortraitData.Heads.Count > 0)
+            if (result.DormFurnitureChanged || result.DormCharacterChanged || result.GatherRewardIds.Count > 0 || result.HeadPortraitData.Heads.Count > 0)
                 session.player.Save();
             result.SendPushes(session);
             return result.RewardGoods;
@@ -521,7 +525,7 @@ namespace AscNet.GameServer.Handlers
         public static void GiveRewards(IEnumerable<Reward> rewards, Session session)
         {
             RewardApplicationResult result = ApplyRewards(rewards, session);
-            if (result.DormFurnitureChanged || result.GatherRewardIds.Count > 0 || result.HeadPortraitData.Heads.Count > 0)
+            if (result.DormFurnitureChanged || result.DormCharacterChanged || result.GatherRewardIds.Count > 0 || result.HeadPortraitData.Heads.Count > 0)
                 session.player.Save();
             result.SendPushes(session);
         }
@@ -813,6 +817,7 @@ namespace AscNet.GameServer.Handlers
                     UnlockHeadPortraitReward(reward.Id, session, headPortraits);
                     break;
                 case RewardType.DormCharacter:
+                    result.DormCharacterChanged |= DormModule.TryGrantDormCharacterReward(session, reward.Id);
                     break;
                 case RewardType.ChatEmoji:
                     break;

--- a/AscNet.GameServer/Handlers/ShopModule.cs
+++ b/AscNet.GameServer/Handlers/ShopModule.cs
@@ -230,6 +230,24 @@ namespace AscNet.GameServer.Handlers
             };
         }
 
+        internal static IEnumerable<int> GetPurchasedDormCharacterRewardIds(Player player)
+        {
+            player.ShopBuyTimes ??= new();
+            foreach (ClientShop shop in RetailShopSnapshot.Value.Values)
+            {
+                foreach (ClientShopGoods goods in shop.GoodsList)
+                {
+                    if (player.ShopBuyTimes.GetValueOrDefault(goods.Id) <= 0
+                        || goods.RewardGoods.RewardType != (int)RewardType.DormCharacter)
+                    {
+                        continue;
+                    }
+
+                    yield return checked((int)goods.RewardGoods.TemplateId);
+                }
+            }
+        }
+
         private static Dictionary<uint, ClientShop> LoadShopSnapshot()
         {
             JObject root = JsonSnapshot.LoadObject(ShopSnapshotPath);


### PR DESCRIPTION
- Added support for Celica in dorm
- Fixed an issue regarding brought corrupted chibis in the dispatch shop not appearing as available residents
- Tested and working with:
       -Celica
       -Roland
       -B5 Pointy
       -B5 Pokey
       -Nozzle
       -Repairer
       -Kemuri
       -Roseblade
       -Shark-spear
- Gives the player one of each available furniture
    -Note: Some furniture are not included
    
    
    
  Method on how to get Celica using Mongodb Compass:
  -Dorm character can be found under:Localhost -> asc_net -> players -> dorm -> characters
  -Celica's Id_number is "1000000", for the dormitory_id put: "-1" (unplaced)