### PR TITLE
GetWeeklyActivenessRewardRequest implementation

### DIFF
--- a/AscNet.Common/MsgPack/Types.cs
+++ b/AscNet.Common/MsgPack/Types.cs
@@ -810,6 +810,7 @@ namespace AscNet.Common.MsgPack
             public List<Int32> NewbieRecvProgress { get; set; } = new();
             public Boolean NewbieHonorReward { get; set; }
             public Int32 NewbieUnlockPeriod { get; set; }
+            public List<Int32> WeeklyTaskActivenessProgress { get; set; } = new();
         }
 
         public NotifyTaskDataTaskData TaskData { get; set; }

--- a/AscNet.GameServer/Handlers/AccountModule.cs
+++ b/AscNet.GameServer/Handlers/AccountModule.cs
@@ -1318,6 +1318,7 @@ namespace AscNet.GameServer.Handlers
                     FinishedTasks = session.stage.FinishedTasks,
                     NewPlayerRewardRecord = session.player.MissionProgress.NewPlayerRewardRecords,
                     NewbieRecvProgress = session.player.MissionProgress.NewbieRewardRecords,
+                    WeeklyTaskActivenessProgress = TaskModule.BuildWeeklyTwoProgress(session),
                     Tasks = TaskModule.BuildTaskData(session),
                 }
             };

--- a/AscNet.GameServer/Handlers/TaskModule.cs
+++ b/AscNet.GameServer/Handlers/TaskModule.cs
@@ -77,6 +77,14 @@ namespace AscNet.GameServer.Handlers
     }
 
     [MessagePackObject(true)]
+    public class GetWeeklyActivenessRewardResponse
+    {
+        public int Code { get; set; }
+        public List<RewardGoods> RewardGoodsList { get; set; } = new();
+        public List<int> WeeklyTaskActivenessProgress { get; set; } = new();
+    }
+
+    [MessagePackObject(true)]
     public class FinishTaskRequest
     {
         public int TaskId { get; set; }
@@ -139,6 +147,9 @@ namespace AscNet.GameServer.Handlers
         });
         private static readonly Lazy<IReadOnlyDictionary<int, int>> GuildBossStageTypes = new(() =>
             TableReaderV2.Parse<GuildBossStageCatalogTable>().ToDictionary(stage => stage.StageId, stage => stage.StageType));
+        // WeeklyTwo activeness counts finished tasks tagged Weekly in Task.tab (client XTaskManager.GetWeeklyTaskActiveness).
+        private static readonly Lazy<IReadOnlySet<int>> WeeklyTaggedTaskIds = new(() =>
+            TableReaderV2.Parse<TaskTable>().Where(task => task.Tag == 1).Select(task => task.Id).ToHashSet());
 
         [RequestPacketHandler("DoClientTaskEventRequest")]
         public static void DoClientTaskEventRequestHandler(Session session, Packet.Request packet)
@@ -406,6 +417,100 @@ namespace AscNet.GameServer.Handlers
                 session.SendPush(BuildActivenessStatus(session));
             }
             session.SendResponse(response, packet.Id);
+        }
+
+        [RequestPacketHandler("GetWeeklyActivenessRewardRequest")]
+        public static void GetWeeklyActivenessRewardRequestHandler(Session session, Packet.Request packet)
+        {
+            session.SendResponse(ClaimWeeklyTwoRewards(session), packet.Id);
+        }
+
+        internal static List<int> BuildWeeklyTwoProgress(Session session)
+        {
+            EnsureMissionResets(session);
+            return WeeklyTwoClaimedMilestones(session);
+        }
+
+        private static GetWeeklyActivenessRewardResponse ClaimWeeklyTwoRewards(Session session)
+        {
+            EnsureMissionResets(session);
+            CurrentTaskActivenessTable? rewards = TableReaderV2.Parse<CurrentTaskActivenessTable>().FirstOrDefault(x => x.Type == 5);
+            if (rewards is null)
+            {
+                return new GetWeeklyActivenessRewardResponse { Code = 20026010 };
+            }
+
+            long week = session.player.MissionProgress.WeeklyResetWeek;
+            int activeness = WeeklyTwoActiveness(session);
+            List<int> rewardIndexes = rewards.Activeness
+                .Select((milestone, index) => (milestone, index))
+                .Where(entry => entry.milestone <= activeness && !WeeklyTwoClaimed(session, week, entry.milestone))
+                .Select(entry => entry.index)
+                .ToList();
+            if (rewardIndexes.Count == 0)
+            {
+                bool hasReachedMilestone = rewards.Activeness.Any(milestone => milestone <= activeness);
+                return new GetWeeklyActivenessRewardResponse { Code = hasReachedMilestone ? 20026012 : 20026010 };
+            }
+            if (rewardIndexes.Any(index => index >= rewards.RewardId.Count))
+            {
+                return new GetWeeklyActivenessRewardResponse { Code = 20026010 };
+            }
+
+            List<RewardGrant> grants = new();
+            foreach (int index in rewardIndexes)
+            {
+                List<RewardGoodsTable> goods = RewardHandler.GetRewardGoods(rewards.RewardId[index]);
+                if (goods.Count == 0)
+                {
+                    return new GetWeeklyActivenessRewardResponse { Code = 20026010 };
+                }
+                grants.Add(new RewardGrant(WeeklyTwoClaimKey(week, rewards.Activeness[index]), goods));
+            }
+
+            RewardApplicationResult application;
+            try
+            {
+                application = RewardHandler.ApplyRewardsOnceAndPersist(grants, session);
+            }
+            catch (Exception exception)
+            {
+                session.log.Error($"Failed to persist weekly activeness rewards: {exception}");
+                return new GetWeeklyActivenessRewardResponse { Code = 20026003 };
+            }
+            application.SendPushes(session);
+            return new GetWeeklyActivenessRewardResponse
+            {
+                Code = 0,
+                RewardGoodsList = application.RewardGoods,
+                WeeklyTaskActivenessProgress = WeeklyTwoClaimedMilestones(session)
+            };
+        }
+
+        private static int WeeklyTwoActiveness(Session session)
+        {
+            IReadOnlySet<int> tagged = WeeklyTaggedTaskIds.Value;
+            return session.player.MissionProgress.ClaimedTaskIds
+                .Concat(session.stage.FinishedTasks)
+                .Distinct()
+                .Count(tagged.Contains);
+        }
+
+        private static string WeeklyTwoClaimKey(long week, int milestone) => $"weekly-two:{week}:{milestone}";
+
+        private static bool WeeklyTwoClaimed(Session session, long week, int milestone) =>
+            session.inventory.AppliedRewardClaims.Contains(WeeklyTwoClaimKey(week, milestone), StringComparer.Ordinal)
+            || session.character.AppliedRewardClaims.Contains(WeeklyTwoClaimKey(week, milestone), StringComparer.Ordinal);
+
+        private static List<int> WeeklyTwoClaimedMilestones(Session session)
+        {
+            CurrentTaskActivenessTable? rewards = TableReaderV2.Parse<CurrentTaskActivenessTable>().FirstOrDefault(x => x.Type == 5);
+            if (rewards is null)
+            {
+                return [];
+            }
+            long week = session.player.MissionProgress.WeeklyResetWeek;
+            return rewards.Activeness.Where(milestone => WeeklyTwoClaimed(session, week, milestone)).ToList();
         }
 
         [RequestPacketHandler("GetNewbieRewardRequest")]

--- a/AscNet.Test/Program.cs
+++ b/AscNet.Test/Program.cs
@@ -474,6 +474,11 @@ namespace AscNet.Test
                     ValidateLoginAccountCompatibility();
                     return;
                 }
+                if (args.Contains("--weekly-activeness-compat-only"))
+                {
+                    ValidateWeeklyActivenessRewardCompatibility();
+                    return;
+                }
                 if (args.Contains("--gate-login-compat-only"))
                 {
                     ValidateGateLoginCompatibility().GetAwaiter().GetResult();
@@ -4219,6 +4224,7 @@ namespace AscNet.Test
             ValidateNewPlayerRewardCompatibility();
             ValidateNewbieRewardCompatibility();
             ValidateActivenessRewardCompatibility();
+            ValidateWeeklyActivenessRewardCompatibility();
             ValidateAchievementRewardCompatibility();
             ValidateLoginStartupPushOrder();
             ValidateReconnectAckClientPushNoReplayStabilityCompatibility();
@@ -4875,6 +4881,107 @@ namespace AscNet.Test
                 maxPacketsToRead: 8);
             AssertEqual(20026012, duplicateResponse.Code, "GetActivenessRewardResponse duplicate Code");
             AssertEqual(0, duplicateResponse.RewardGoodsList.Count, "GetActivenessRewardResponse duplicate reward count");
+        }
+
+        private static void ValidateWeeklyActivenessRewardCompatibility()
+        {
+            using MongoCollectionOverride mongoOverride = MongoCollectionOverride.InstallForShopCompatibility();
+            const long playerId = 88_045;
+            AscNet.Common.Database.Player player = CreateDrawCompatibilityPlayer(playerId);
+            List<int> taggedTaskIds = TableReaderV2.Parse<TaskTable>()
+                .Where(task => task.Tag == 1)
+                .Select(task => task.Id)
+                .ToList();
+            if (taggedTaskIds.Count < 10)
+                throw new InvalidDataException($"Weekly-two activeness test requires at least 10 Tag=1 tasks, found {taggedTaskIds.Count}.");
+            AscNet.Common.Database.Inventory inventory = CreateDrawCompatibilityInventory(playerId, []);
+            using LoopbackSessionHarness harness = new(
+                CreateDrawCompatibilityCharacter(playerId),
+                player,
+                inventory,
+                "weekly-activeness-reward-compat-test");
+            harness.Session.stage = new AscNet.Common.Database.Stage
+            {
+                Uid = playerId,
+                Stages = new(),
+                Course = new(),
+                FinishedTasks = new()
+            };
+
+            RequestPacketHandlerDelegate handler = GetRegisteredRequestHandler("GetWeeklyActivenessRewardRequest");
+
+            player.MissionProgress.ClaimedTaskIds = taggedTaskIds.Take(4).ToList();
+            const int belowPacketId = 13_210;
+            handler.Invoke(harness.Session, new Packet.Request
+            {
+                Id = belowPacketId,
+                Name = "GetWeeklyActivenessRewardRequest",
+                Content = [0xC0]
+            });
+            GetWeeklyActivenessRewardResponse belowResponse = ReadResponsePayload<GetWeeklyActivenessRewardResponse>(
+                harness,
+                belowPacketId,
+                nameof(GetWeeklyActivenessRewardResponse),
+                "GetWeeklyActivenessRewardRequest below-milestone response",
+                maxPacketsToRead: 16);
+            AssertEqual(20026010, belowResponse.Code, "GetWeeklyActivenessRewardResponse below-milestone Code");
+            AssertEqual(0, belowResponse.RewardGoodsList.Count, "GetWeeklyActivenessRewardResponse below-milestone reward count");
+
+            long week = player.MissionProgress.WeeklyResetWeek;
+            player.MissionProgress.ClaimedTaskIds = taggedTaskIds.Take(5).ToList();
+            const int firstPacketId = 13_211;
+            handler.Invoke(harness.Session, new Packet.Request
+            {
+                Id = firstPacketId,
+                Name = "GetWeeklyActivenessRewardRequest",
+                Content = [0xC0]
+            });
+            GetWeeklyActivenessRewardResponse firstResponse = ReadResponsePayload<GetWeeklyActivenessRewardResponse>(
+                harness,
+                firstPacketId,
+                nameof(GetWeeklyActivenessRewardResponse),
+                "GetWeeklyActivenessRewardRequest first-milestone response",
+                maxPacketsToRead: 16);
+            AssertEqual(0, firstResponse.Code, "GetWeeklyActivenessRewardResponse first-milestone Code");
+            AssertEqual(1, firstResponse.RewardGoodsList.Count, "GetWeeklyActivenessRewardResponse first-milestone reward count");
+            AssertIntegerList([5], firstResponse.WeeklyTaskActivenessProgress.Select(value => (long)value).ToArray(),
+                "GetWeeklyActivenessRewardResponse first-milestone progress");
+            AssertEqual(true, inventory.AppliedRewardClaims.Contains($"weekly-two:{week}:5", StringComparer.Ordinal),
+                "GetWeeklyActivenessRewardRequest persisted first claim key");
+
+            player.MissionProgress.ClaimedTaskIds = taggedTaskIds.Take(10).ToList();
+            const int secondPacketId = 13_212;
+            handler.Invoke(harness.Session, new Packet.Request
+            {
+                Id = secondPacketId,
+                Name = "GetWeeklyActivenessRewardRequest",
+                Content = [0xC0]
+            });
+            GetWeeklyActivenessRewardResponse secondResponse = ReadResponsePayload<GetWeeklyActivenessRewardResponse>(
+                harness,
+                secondPacketId,
+                nameof(GetWeeklyActivenessRewardResponse),
+                "GetWeeklyActivenessRewardRequest second-milestone response",
+                maxPacketsToRead: 16);
+            AssertEqual(0, secondResponse.Code, "GetWeeklyActivenessRewardResponse second-milestone Code");
+            AssertEqual(1, secondResponse.RewardGoodsList.Count, "GetWeeklyActivenessRewardResponse second-milestone reward count");
+            AssertIntegerList([5, 10], secondResponse.WeeklyTaskActivenessProgress.Select(value => (long)value).ToArray(),
+                "GetWeeklyActivenessRewardResponse second-milestone progress");
+
+            const int duplicatePacketId = 13_213;
+            handler.Invoke(harness.Session, new Packet.Request
+            {
+                Id = duplicatePacketId,
+                Name = "GetWeeklyActivenessRewardRequest",
+                Content = [0xC0]
+            });
+            GetWeeklyActivenessRewardResponse duplicateResponse = ReadResponsePayload<GetWeeklyActivenessRewardResponse>(
+                harness,
+                duplicatePacketId,
+                nameof(GetWeeklyActivenessRewardResponse),
+                "GetWeeklyActivenessRewardRequest duplicate response");
+            AssertEqual(20026012, duplicateResponse.Code, "GetWeeklyActivenessRewardResponse duplicate Code");
+            AssertEqual(0, duplicateResponse.RewardGoodsList.Count, "GetWeeklyActivenessRewardResponse duplicate reward count");
         }
 
         private static void ValidateAchievementRewardCompatibility()


### PR DESCRIPTION
# Support `GetWeeklyActivenessRewardRequest`

## Problem

The game server logged an unhandled request on login/task-panel use:

```
[WARN]: Request handler not found: name="GetWeeklyActivenessRewardRequest", nameLength=32, contentBytes=1, id=273
```

The client calls this with an empty body `{}` when the player claims Weekly (WeeklyTwo) activeness rewards. No handler was registered, so the reward was never granted.

## What the request is

- Client call: `XTaskManager:GetWeeklyActivenessRewardRequest` (`XTaskManager.lua:782`).
- Response fields the client reads: `Code`, `RewardGoodsList`, `WeeklyTaskActivenessProgress`.
- `WeeklyTaskActivenessProgress` is the **full** set of activeness milestone values already claimed this week (the client replaces its local cache with this list).
- The track is `CurrentTaskActivenessTable.Type == 5` (`CurrentTaskActiveness.tsv`): milestones `[5, 10]`, rewards `[68860, 68870]`.
- Activeness is not an item: the client derives it from finished tasks tagged `Weekly` in `Task.tab` (`XTaskManager.GetWeeklyTaskActiveness`, `XTaskManager.lua:1700`). Server-side equivalent is the count of `(ClaimedTaskIds ∪ stage.FinishedTasks)` whose `TaskTable.Tag == 1`.
- Rewards `68860/68870` resolve through the normal `Reward.tab` (`688600/688700` → item `106` "Makeup Sign-in Card"), **not** `CurrentReward.tab`, so this path uses `RewardHandler.GetRewardGoods`.

## Implementation

- Added `GetWeeklyActivenessRewardResponse { Code, RewardGoodsList, WeeklyTaskActivenessProgress }`.
- Registered `[RequestPacketHandler("GetWeeklyActivenessRewardRequest")]`; the body is empty and ignored.
- Activeness is counted from the authoritative task tables and persisted player/session state (no hardcoded values).
- Claims use the repo's current idempotency convention: `RewardHandler.ApplyRewardsOnceAndPersist` with a week-scoped claim key `weekly-two:{week}:{milestone}` stored in `AppliedRewardClaims` (mirrors `current-task:{taskId}:{week}`). No new persisted DB field.
- `WeeklyTaskActivenessProgress` is derived by scanning the current week's claim keys.
- Weekly rollover naturally re-enables claims because the key embeds `MissionProgress.WeeklyResetWeek`.
- Populated `NotifyTaskData.TaskData.WeeklyTaskActivenessProgress` at login so claimed checkmarks survive relog (the client already reads `data.TaskData.WeeklyTaskActivenessProgress`, `XTaskManager.lua:370`).
- Error codes reuse the existing activeness family: `20026010` (not reached / config or reward missing), `20026012` (already claimed), `20026003` (persist failure). Success is `0`.

## Files changed

| File | Change |
| --- | --- |
| `AscNet.GameServer/Handlers/TaskModule.cs` | Response DTO, `WeeklyTaggedTaskIds`, `GetWeeklyActivenessRewardRequest` handler, `ClaimWeeklyTwoRewards` / `BuildWeeklyTwoProgress` / claim-key helpers |
| `AscNet.Common/MsgPack/Types.cs` | `WeeklyTaskActivenessProgress` on `NotifyTaskDataTaskData` |
| `AscNet.GameServer/Handlers/AccountModule.cs` | Populate `WeeklyTaskActivenessProgress` at login |
| `AscNet.Test/Program.cs` | `ValidateWeeklyActivenessRewardCompatibility` (wired into `ValidateLoginAccountCompatibility`) + `--weekly-activeness-compat-only` switch |

## Verification

Builds clean (0 warnings / 0 errors) for `AscNet.Common`, `AscNet.GameServer`, `AscNet.Test`.

Focused harness (`dotnet run --project AscNet.Test/AscNet.Test.csproj -- --weekly-activeness-compat-only`, exit 0):

| Claimed tagged tasks | Result |
| --- | --- |
| 4 | `Code = 20026010`, no rewards |
| 5 | `Code = 0`, reward `688600`, progress `[5]` |
| 10 | `Code = 0`, reward `688700`, progress `[5, 10]` |
| repeat | `Code = 20026012`, no rewards |

`--login-account-compat-only` passes (exit 0), confirming the login payload addition does not regress login shape or startup push order.

### Known unrelated failure

The full default harness stops at a pre-existing failure in `ValidateBossSingleCompatibility`:

```
Pain Cage rollover archives stage best: expected 'True', got 'False'
```

Reproduced with the login field temporarily removed, so it is unrelated to this change (and aborts the harness before later validations run).

## AGENTS.MD compliance

- **No hardcoded protocol data**: activeness, milestones, reward IDs, and the tagged-task set are read from authoritative tables (`CurrentTaskActiveness.tsv`, `Reward.tsv`, `Task.tsv`); claim state comes from persisted `AppliedRewardClaims`. No captured payloads, retail IDs, balances, or timestamps are embedded. `Type == 5` and `Tag == 1` are table semantics (same style as the existing `x.Type == 3/4` checks), and the error codes reuse existing server protocol values.
- **Tables authoritative**: no TSV or generated table source was hand-edited.
- **DTOs**: `GetWeeklyActivenessRewardResponse` uses the named-key `[MessagePackObject(true)]` pattern, co-located with the sibling task DTOs per the module's existing convention; the shared/persisted login schema change lives in `AscNet.Common/MsgPack/Types.cs` as AGENTS prescribes.
- **Handler mechanics**: `[RequestPacketHandler("GetWeeklyActivenessRewardRequest")]`, response sent with the request's `packet.Id`. The request body is empty (`{}`), so no request DTO is deserialized — consistent with `GetNewbieRewardRequestHandler` / `GetNewbieHonorRewardRequestHandler`.
- **Persistence**: grants go through `RewardHandler.ApplyRewardsOnceAndPersist`, which saves inventory/character with rollback on failure.
- **Testing**: narrow `--weekly-activeness-compat-only` first, then the full harness; derived fields covered with distinct states (4 / 5 / 10). The one full-harness failure is pre-existing and unrelated (see above).
- **No captures / artifacts**: no packet captures, `.runtime/`, `bin/`, `obj/`, or runtime logs added.

## Notes / follow-ups

- Week-scoped claim keys accumulate (~2/week) and are not pruned, consistent with existing `current-task:` keys.
- `InvalidDataException`/error handling and reward rollback are delegated to `RewardHandler.ApplyRewardsOnceAndPersist`.
